### PR TITLE
 Adding capability to handle both UID and Email as username with Cloud

### DIFF
--- a/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/model/AgentConfiguration.java
+++ b/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/model/AgentConfiguration.java
@@ -23,6 +23,15 @@ package org.wso2.carbon.identity.agent.userstore.model;
 public class AgentConfiguration {
 
     private String serverUrl;
+    private String tenantDomain;
+
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
 
     public String getServerUrl() {
         return serverUrl;

--- a/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/util/UserStoreUtils.java
+++ b/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/util/UserStoreUtils.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.agent.userstore.util;
 
+import org.wso2.carbon.identity.agent.userstore.config.AgentConfigUtil;
 import org.wso2.carbon.identity.agent.userstore.constant.CommonConstants;
 
 /**
@@ -40,5 +41,14 @@ public class UserStoreUtils {
             combinedName = userName;
         }
         return combinedName;
+    }
+
+    public static String getUserStoreAwareUsername(String username) {
+        String tenantDomain = AgentConfigUtil.build().getTenantDomain();
+        if (username.contains("@") &&
+                tenantDomain.equals(username.substring(username.indexOf("@") + 1))) {
+            username = username.substring(0, username.indexOf(tenantDomain) - 1);
+        }
+        return username;
     }
 }

--- a/conf/assembly-outbound.xml
+++ b/conf/assembly-outbound.xml
@@ -32,7 +32,7 @@
         <file>
             <source>../../conf/wso2agent.sh</source>
             <outputDirectory>wso2agent-${pom.version}</outputDirectory>
-            <fileMode>644</fileMode>
+            <fileMode>755</fileMode>
         </file>
         <file>
             <source>../../conf/wso2agent.bat</source>
@@ -42,7 +42,7 @@
         <file>
             <source>../../conf/ciphertool.sh</source>
             <outputDirectory>wso2agent-${pom.version}</outputDirectory>
-            <fileMode>644</fileMode>
+            <fileMode>755</fileMode>
         </file>
         <file>
             <source>../../conf/ciphertool.bat</source>

--- a/conf/assembly-server.xml
+++ b/conf/assembly-server.xml
@@ -27,7 +27,7 @@
         <file>
             <source>../../conf/wso2server.sh</source>
             <outputDirectory>wso2server-${pom.version}</outputDirectory>
-            <fileMode>644</fileMode>
+            <fileMode>755</fileMode>
         </file>
         <file>
             <source>../../conf/conf/deployment.yml</source>

--- a/conf/assembly.xml
+++ b/conf/assembly.xml
@@ -30,7 +30,7 @@
         <file>
             <source>../../conf/wso2agent.sh</source>
             <outputDirectory>wso2agent-${pom.version}</outputDirectory>
-            <fileMode>644</fileMode>
+            <fileMode>755</fileMode>
         </file>
         <file>
             <source>../../conf/wso2agent.bat</source>
@@ -40,7 +40,7 @@
         <file>
             <source>../../conf/ciphertool.sh</source>
             <outputDirectory>wso2agent-${pom.version}</outputDirectory>
-            <fileMode>644</fileMode>
+            <fileMode>755</fileMode>
         </file>
         <file>
             <source>../../conf/ciphertool.bat</source>

--- a/conf/conf/agent-config.yml
+++ b/conf/conf/agent-config.yml
@@ -1,1 +1,2 @@
-serverUrl: "wss://identitybroker.cloudstaging.wso2.com:8443/server"
+serverUrl: "wss://identitybroker.cloud.wso2.com:8443/server"
+tenantDomain: "wso2cloudtenantdomain"

--- a/conf/conf/userstore-config.xml
+++ b/conf/conf/userstore-config.xml
@@ -17,7 +17,7 @@
 		<Property name="ConnectionURL">ldap://localhost:10389</Property>
 		<Property name="ConnectionName">uid=admin,ou=system</Property>
 		<Property name="ConnectionPassword">admin</Property>
-		<Property name="UserSearchBase">ou=system</Property>
+		<Property name="UserSearchBase">ou=Users,dc=wso2,dc=org</Property>
 		<Property name="UserNameAttribute">uid</Property>
 		<Property name="UserNameSearchFilter">(&amp;(objectClass=person)(uid=?))</Property>
 		<Property name="UserNameListFilter">(objectClass=person)</Property>


### PR DESCRIPTION
## Purpose
> On-Premise Agent cannot handle UID and Email as the username with WSO2 API Cloud

## Goals
> Adding capability to handle both UID and Email as the username with Cloud

## Approach
> In the UID case, API Cloud will send the tenant domain appended with the username so that it will behave in the same way as an Email in API Cloud. Inside agent tenant domain will be removed before any user operation (tenant domain needs to be configured in agent-config.yaml)

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> None

## Test environment
> WSO2 Cloud, MacOS High Siera 10.13.6, JDK 1.8.0_162
 
## Learning
> None