### PR TITLE
Add "start/stop" command line arguement to wso2agent.sh script

### DIFF
--- a/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/Application.java
+++ b/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/Application.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.agent.userstore.manager.common.UserStoreManagerB
 import org.wso2.carbon.identity.agent.userstore.resource.StatusResource;
 import org.wso2.carbon.identity.agent.userstore.security.AccessTokenHandler;
 import org.wso2.carbon.identity.agent.userstore.security.SecretManagerInitializer;
+import org.wso2.carbon.identity.agent.userstore.util.ApplicationUtils;
 import org.wso2.msf4j.MicroservicesRunner;
 
 import java.net.InetAddress;
@@ -55,6 +56,7 @@ public class Application {
      */
     private void startAgent() throws UnknownHostException {
 
+        ApplicationUtils.writePID();
         String accessToken = new AccessTokenHandler().getAccessToken();
         if (StringUtils.isEmpty(accessToken)) {
             LOGGER.error("Please enter valid access token.");

--- a/conf/wso2agent.sh
+++ b/conf/wso2agent.sh
@@ -153,6 +153,24 @@ if [ "$CMD" = "--debug" ]; then
   CMD="RUN"
   JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
   echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$CARBON_HOME/wso2agent.pid" ]; then
+    PID=`cat "$CARBON_HOME"/wso2agent.pid`
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  if [ ! -f "$CARBON_HOME/accesstoken" ]; then
+      echo "Enter installation token :"
+      stty -echo
+      read token
+      stty echo
+      printf "%s" "$token" > accesstoken
+  fi
+  # using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/wso2agent.sh $args > /dev/null 2>&1 &
+  exit 0
 elif [ "$CMD" = "stop" ]; then
   kill -term `cat "$CARBON_HOME"/wso2agent.pid`
   exit 0

--- a/conf/wso2agent.sh
+++ b/conf/wso2agent.sh
@@ -153,6 +153,9 @@ if [ "$CMD" = "--debug" ]; then
   CMD="RUN"
   JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
   echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "stop" ]; then
+  kill -term `cat "$CARBON_HOME"/wso2agent.pid`
+  exit 0
 fi
 echo "###############################################################################################################"
 echo "#                                                                                                             #"


### PR DESCRIPTION
## Purpose
> This PR add command line argument "start" and "stop" to the wso2agent.sh script.

## Goals
> This eliminates the manual process of finding and terminating the relevant process ID in order to stop the identity agent. 
Start command will run the agent in the background after acquiring the installation token.
## Approach
>

## User stories
> 
## Release note
> 

## Documentation
> 
## Training
> 

## Certification
> 

## Marketing
> 
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> 
## Related PRs
> 
## Migrations (if applicable)
> 
## Test environment
> JDK versions - 1.8
 
## Learning
> 