### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/AgentMgtDao.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/AgentMgtDao.java
@@ -60,6 +60,13 @@ public class AgentMgtDao {
             prepStmt.executeUpdate();
             dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error(
+                        "SQL transaction rollback connection error occurred while updating connection client node: "
+                                + node + " server node: " + serverNode + " status: " + status, e1);
+            }
             String errorMessage = "Error occurred while updating connection client node: " + node + " server node: " +
                     serverNode + " status: " + status;
             LOGGER.error(errorMessage, e);
@@ -88,6 +95,12 @@ public class AgentMgtDao {
             prepStmt.executeUpdate();
             dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error("SQL transaction rollback connection error occurred while updating connection"
+                        + " status server node: " + serverNode, e1);
+            }
             String errorMessage = "Error occurred while updating connection status server node: " + serverNode;
             LOGGER.error(errorMessage, e);
             result = false;
@@ -119,7 +132,14 @@ public class AgentMgtDao {
             if (resultSet.next()) {
                 isValid = true;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error("SQL transaction rollback connection error occurred while checking node connection node: "
+                        + node, e1);
+            }
             String errorMessage = "Error occurred while checking node connection node: " + node;
             LOGGER.error(errorMessage, e);
         } finally {
@@ -152,7 +172,14 @@ public class AgentMgtDao {
             if (resultSet.next()) {
                 serverNode = resultSet.getString(1);
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error("SQL transaction rollback connection error occurred while checking server connected for : "
+                        + node, e1);
+            }
             String errorMessage = "Error occurred while checking server connected for : " + node;
             LOGGER.error(errorMessage, e);
         } finally {
@@ -183,7 +210,15 @@ public class AgentMgtDao {
             if (resultSet.next()) {
                 isExist = true;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error(
+                        "SQL transaction rollback connection error occurred while checking sconnection node: " + node,
+                        e1);
+            }
             String errorMessage = "Error occurred while checking connection node: " + node;
             LOGGER.error(errorMessage, e);
         } finally {
@@ -211,6 +246,12 @@ public class AgentMgtDao {
             prepStmt.executeUpdate();
             dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error("SQL transaction rollback connection error occurred whileadding connection information",
+                        e1);
+            }
             String errorMessage = "Error occurred while adding connection information.";
             LOGGER.error(errorMessage, e);
             result = false;
@@ -247,7 +288,14 @@ public class AgentMgtDao {
                 agentConnection.setServerNode(resultSet.getString("UM_SERVER_NODE"));
                 agentConnections.add(agentConnection);
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error("SQL transaction rollback connection error occurred while reading agent connection "
+                        + "information tenant: " + tenantDomain + " domain: " + domain + " status: " + status, e1);
+            }
             String errorMessage = "Error occurred while reading agent connection information tenant: " +  tenantDomain +
                     " domain: " + domain + " status: " + status;
             LOGGER.error(errorMessage, e);

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/AgentMgtDao.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/AgentMgtDao.java
@@ -60,13 +60,7 @@ public class AgentMgtDao {
             prepStmt.executeUpdate();
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error(
-                        "SQL transaction rollback connection error occurred while updating connection client node: "
-                                + node + " server node: " + serverNode + " status: " + status, e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while updating connection client node: " + node + " server node: " +
                     serverNode + " status: " + status;
             LOGGER.error(errorMessage, e);
@@ -95,12 +89,7 @@ public class AgentMgtDao {
             prepStmt.executeUpdate();
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error("SQL transaction rollback connection error occurred while updating connection"
-                        + " status server node: " + serverNode, e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while updating connection status server node: " + serverNode;
             LOGGER.error(errorMessage, e);
             result = false;
@@ -134,12 +123,7 @@ public class AgentMgtDao {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error("SQL transaction rollback connection error occurred while checking node connection node: "
-                        + node, e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while checking node connection node: " + node;
             LOGGER.error(errorMessage, e);
         } finally {
@@ -174,12 +158,7 @@ public class AgentMgtDao {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error("SQL transaction rollback connection error occurred while checking server connected for : "
-                        + node, e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while checking server connected for : " + node;
             LOGGER.error(errorMessage, e);
         } finally {
@@ -212,13 +191,7 @@ public class AgentMgtDao {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error(
-                        "SQL transaction rollback connection error occurred while checking sconnection node: " + node,
-                        e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while checking connection node: " + node;
             LOGGER.error(errorMessage, e);
         } finally {
@@ -246,12 +219,7 @@ public class AgentMgtDao {
             prepStmt.executeUpdate();
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error("SQL transaction rollback connection error occurred whileadding connection information",
-                        e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while adding connection information.";
             LOGGER.error(errorMessage, e);
             result = false;
@@ -290,12 +258,7 @@ public class AgentMgtDao {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error("SQL transaction rollback connection error occurred while reading agent connection "
-                        + "information tenant: " + tenantDomain + " domain: " + domain + " status: " + status, e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while reading agent connection information tenant: " +  tenantDomain +
                     " domain: " + domain + " status: " + status;
             LOGGER.error(errorMessage, e);

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/AgentMgtDao.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/AgentMgtDao.java
@@ -58,7 +58,7 @@ public class AgentMgtDao {
             prepStmt.setInt(3, accessTokenId);
             prepStmt.setString(4, node);
             prepStmt.executeUpdate();
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while updating connection client node: " + node + " server node: " +
@@ -87,7 +87,7 @@ public class AgentMgtDao {
             prepStmt.setString(1, status);
             prepStmt.setString(2, serverNode);
             prepStmt.executeUpdate();
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while updating connection status server node: " + serverNode;
@@ -121,7 +121,7 @@ public class AgentMgtDao {
             if (resultSet.next()) {
                 isValid = true;
             }
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while checking node connection node: " + node;
@@ -156,7 +156,7 @@ public class AgentMgtDao {
             if (resultSet.next()) {
                 serverNode = resultSet.getString(1);
             }
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while checking server connected for : " + node;
@@ -189,7 +189,7 @@ public class AgentMgtDao {
             if (resultSet.next()) {
                 isExist = true;
             }
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while checking connection node: " + node;
@@ -217,7 +217,7 @@ public class AgentMgtDao {
             prepStmt.setString(3, connection.getStatus());
             prepStmt.setString(4, connection.getServerNode());
             prepStmt.executeUpdate();
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while adding connection information.";
@@ -256,7 +256,7 @@ public class AgentMgtDao {
                 agentConnection.setServerNode(resultSet.getString("UM_SERVER_NODE"));
                 agentConnections.add(agentConnection);
             }
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while reading agent connection information tenant: " +  tenantDomain +

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/TokenMgtDao.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/TokenMgtDao.java
@@ -60,11 +60,7 @@ public class TokenMgtDao {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                LOGGER.error("SQL transaction rollback connection error occurred while validating access token ", e1);
-            }
+            DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while validating access token";
             LOGGER.error(errorMessage, e);
         } finally {

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/TokenMgtDao.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/TokenMgtDao.java
@@ -58,7 +58,13 @@ public class TokenMgtDao {
                 token.setStatus(resultSet.getString("UM_STATUS"));
                 return token;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                LOGGER.error("SQL transaction rollback connection error occurred while validating access token ", e1);
+            }
             String errorMessage = "Error occurred while validating access token";
             LOGGER.error(errorMessage, e);
         } finally {

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/TokenMgtDao.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/dao/TokenMgtDao.java
@@ -58,7 +58,7 @@ public class TokenMgtDao {
                 token.setStatus(resultSet.getString("UM_STATUS"));
                 return token;
             }
-            dbConnection.commit();
+            DatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(dbConnection);
             String errorMessage = "Error occurred while validating access token";

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/util/DatabaseUtil.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/util/DatabaseUtil.java
@@ -184,4 +184,19 @@ public class DatabaseUtil {
         }
     }
 
+    /**
+     * Commit the transaction.
+     *
+     * @param dbConnection database connection.
+     */
+    public static void commitTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.commit();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while commit transactions. ", e1);
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/util/DatabaseUtil.java
+++ b/components/org.wso2.carbon.identity.agent.outbound.server/src/main/java/org/wso2/carbon/identity/agent/outbound/server/util/DatabaseUtil.java
@@ -168,4 +168,20 @@ public class DatabaseUtil {
         closeConnection(dbConnection);
     }
 
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param dbConnection Database connection.
+     */
+    public static void rollbackTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while rolling back transactions. ", e1);
+        }
+    }
+
 }

--- a/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/manager/jdbc/JDBCUserStoreManager.java
+++ b/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/manager/jdbc/JDBCUserStoreManager.java
@@ -82,7 +82,14 @@ public class JDBCUserStoreManager implements UserStoreManager {
                 }
                 values.put(attributeName, attributeValue);
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error("SQL transaction rollback connection error occurred while retrieving user "
+                                + "attribute info. ", e1);
+            }
             String message = "Error occurred while retrieving user attribute info.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -145,7 +152,14 @@ public class JDBCUserStoreManager implements UserStoreManager {
                     isAuthed = true;
                 }
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error("SQL transaction rollback connection error occurred while retrieving user "
+                                + "attribute info. ", e1);
+            }
             String message = "Error occurred while retrieving user authentication info.";
             log.error(message, e);
             throw new UserStoreException("Authentication Failure");
@@ -216,7 +230,13 @@ public class JDBCUserStoreManager implements UserStoreManager {
                 users = userList.toArray(new String[userList.size()]);
             }
             Arrays.sort(users);
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error("SQL transaction rollback connection error occurred while retrieving users. ", e1);
+            }
             String message = "An error occurred while retrieving users.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -286,7 +306,14 @@ public class JDBCUserStoreManager implements UserStoreManager {
                 roles = lst.toArray(new String[lst.size()]);
             }
 
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error("SQL transaction rollback connection error occurred while retrieving role names. ",
+                        e1);
+            }
             String message = "Error occurred while retrieving role names.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -335,7 +362,13 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (roleList.size() > 0) {
                 roleNames = roleList.toArray(new String[roleList.size()]);
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error("SQL transaction rollback connection error occurred while string values. ", e1);
+            }
             String message = "Error occurred while retrieving string values.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -384,7 +417,15 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (resultSet.next()) {
                 isExisting = true;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error(
+                        "SQL transaction rollback connection error occurred while checking the user "
+                                + "existence in the database. ", e1);
+            }
             String message = "An error occurred while checking the user existence in the database";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -464,7 +505,15 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (resultSet.next()) {
                 isExisting = true;
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error(
+                        "SQL transaction rollback connection error occurred while checking the role "
+                                + "existence in the database. ", e1);
+            }
             String message = "An error occurred while checking the role existence in the database";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -521,7 +570,15 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (userList.size() > 0) {
                 names = userList.toArray(new String[userList.size()]);
             }
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error(
+                        "SQL transaction rollback connection error occurred while retrieving the user "
+                                + "list for a given role. ", e1);
+            }
             String message = "Error occurred while retrieving the user list for a given role.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -685,7 +742,14 @@ public class JDBCUserStoreManager implements UserStoreManager {
         Connection dbConnection = null;
         try {
             dbConnection = getDBConnection();
+            dbConnection.commit();
         } catch (SQLException e) {
+            try {
+                dbConnection.rollback();
+            } catch (SQLException e1) {
+                log.error("SQL transaction rollback connection error occurred while connecting to the"
+                        + " database ", e1);
+            }
             String message = "An error occured while connecting to the database";
             log.error(message, e);
             throw new UserStoreException(message);

--- a/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/manager/jdbc/JDBCUserStoreManager.java
+++ b/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/manager/jdbc/JDBCUserStoreManager.java
@@ -84,12 +84,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error("SQL transaction rollback connection error occurred while retrieving user "
-                                + "attribute info. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving user attribute info.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -154,12 +149,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error("SQL transaction rollback connection error occurred while retrieving user "
-                                + "attribute info. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving user authentication info.";
             log.error(message, e);
             throw new UserStoreException("Authentication Failure");
@@ -232,11 +222,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             Arrays.sort(users);
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error("SQL transaction rollback connection error occurred while retrieving users. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "An error occurred while retrieving users.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -308,12 +294,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
 
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error("SQL transaction rollback connection error occurred while retrieving role names. ",
-                        e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving role names.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -364,11 +345,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error("SQL transaction rollback connection error occurred while string values. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving string values.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -419,13 +396,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error(
-                        "SQL transaction rollback connection error occurred while checking the user "
-                                + "existence in the database. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "An error occurred while checking the user existence in the database";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -507,13 +478,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error(
-                        "SQL transaction rollback connection error occurred while checking the role "
-                                + "existence in the database. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "An error occurred while checking the role existence in the database";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -572,13 +537,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error(
-                        "SQL transaction rollback connection error occurred while retrieving the user "
-                                + "list for a given role. ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving the user list for a given role.";
             log.error(message, e);
             throw new UserStoreException(message, e);
@@ -744,12 +703,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             dbConnection = getDBConnection();
             dbConnection.commit();
         } catch (SQLException e) {
-            try {
-                dbConnection.rollback();
-            } catch (SQLException e1) {
-                log.error("SQL transaction rollback connection error occurred while connecting to the"
-                        + " database ", e1);
-            }
+            rollbackTransaction(dbConnection);
             String message = "An error occured while connecting to the database";
             log.error(message, e);
             throw new UserStoreException(message);
@@ -935,6 +889,22 @@ public class JDBCUserStoreManager implements UserStoreManager {
             String message = "Error occurred while preparing the password.";
             log.error(message, e);
             throw new UserStoreException(message, e);
+        }
+    }
+
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param dbConnection Database connection.
+     */
+    private void rollbackTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while rolling back transactions. ", e1);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/manager/jdbc/JDBCUserStoreManager.java
+++ b/components/org.wso2.carbon.identity.agent.userstore/src/main/java/org/wso2/carbon/identity/agent/userstore/manager/jdbc/JDBCUserStoreManager.java
@@ -82,7 +82,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
                 }
                 values.put(attributeName, attributeValue);
             }
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving user attribute info.";
@@ -147,7 +147,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
                     isAuthed = true;
                 }
             }
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving user authentication info.";
@@ -220,7 +220,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
                 users = userList.toArray(new String[userList.size()]);
             }
             Arrays.sort(users);
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "An error occurred while retrieving users.";
@@ -291,8 +291,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (lst.size() > 0) {
                 roles = lst.toArray(new String[lst.size()]);
             }
-
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving role names.";
@@ -343,7 +342,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (roleList.size() > 0) {
                 roleNames = roleList.toArray(new String[roleList.size()]);
             }
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving string values.";
@@ -394,7 +393,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (resultSet.next()) {
                 isExisting = true;
             }
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "An error occurred while checking the user existence in the database";
@@ -476,7 +475,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (resultSet.next()) {
                 isExisting = true;
             }
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "An error occurred while checking the role existence in the database";
@@ -535,7 +534,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
             if (userList.size() > 0) {
                 names = userList.toArray(new String[userList.size()]);
             }
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "Error occurred while retrieving the user list for a given role.";
@@ -701,7 +700,7 @@ public class JDBCUserStoreManager implements UserStoreManager {
         Connection dbConnection = null;
         try {
             dbConnection = getDBConnection();
-            dbConnection.commit();
+            commitTransaction(dbConnection);
         } catch (SQLException e) {
             rollbackTransaction(dbConnection);
             String message = "An error occured while connecting to the database";
@@ -905,6 +904,22 @@ public class JDBCUserStoreManager implements UserStoreManager {
             }
         } catch (SQLException e1) {
             log.error("An error occurred while rolling back transactions. ", e1);
+        }
+    }
+
+    /**
+     * Commit the transaction.
+     *
+     * @param dbConnection database connection.
+     */
+    private void commitTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.commit();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while commit transactions. ", e1);
         }
     }
 }


### PR DESCRIPTION


## Purpose
When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the identity-agent-onprem-userstore repository, there are some places use the JDBC transaction but did not properly rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5456